### PR TITLE
Added implementation of a unique datatype printer (as requested by Ma…

### DIFF
--- a/src/specificationstuff/CANEnumParser.java
+++ b/src/specificationstuff/CANEnumParser.java
@@ -30,6 +30,7 @@ import emreparser.*;
  * @author 20172420
  */
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 
 public class CANEnumParser {
@@ -240,6 +241,8 @@ public class CANEnumParser {
 		
 		List<String> result = new ArrayList<String>();
 
+		printUniqueTypes(l1);
+
 		for (int i = 0; i < l1.size() + 1; i++) {
 			String dataType = l1.get(i);
 			dataType.replaceAll(" ", ""); //make "bool: 1" and "bool:1" equivalent
@@ -363,6 +366,23 @@ public class CANEnumParser {
 				}
 		}
 		return result;
+	}
+
+	/**
+	 * Iterate over a List of Strings and filter out all unique datatypes that are present in this List
+	 *
+	 * Print all the unique datatypes that remain from this list.
+	 */
+	public void printUniqueTypes(List<String> listOfTypes) {
+		// Do a conversion using a Set, since this collection prohibits duplicates it will do the filtering for us
+		List<String> uniqueList = new ArrayList<>(new HashSet<>(listOfTypes));
+
+		// Now that we have a list of unique Strings, print them out
+		System.out.println("The following unique Strings were found in this List: ");
+		for (String s : uniqueList) {
+			System.out.println("- " + s);
+		}
+		System.out.println();
 	}
 
 	HashMap<String, HashMap<String, String>> enums = parseTypedef(); //the hashmap of enums with their corresponding byte sequence. See overview on the drive for details.


### PR DESCRIPTION
## Proposed changes

Mathijs requested a way to print out the unique datatypes that were present in a list. This implementation provides a method that does exactly that. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
No unit tests are included for this method.

### Manual testing

Pass a list with duplicate strings to the "void printUniqueTypes(List<String> ls)" method. 
Observe that only unique strings are printed to the system output. 

Example of possible input and (approximate) output: 
Input: ["hello", "hello", "bye", "thanks", "hello"]
Output: "hello", "bye", "thanks"
